### PR TITLE
CHANGED: Allow generating class as command class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    crossbeam (0.1.1)
+    crossbeam (0.1.2)
       activemodel (>= 3.0)
       dry-initializer (~> 3.1)
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,16 @@ class IdentityCheck
 end
 ```
 
+Not everyone wants to have their classes output to `app/services/**` sometimes you may prefer the class to be output to `app/commands/**`. Depending on the functionality you working on command classes are very regularly used design pattern.
+
+The generator option in order to generate your classes as a command can be flagged with `--command`.
+
+```shell
+rails g crossbream AgeCheck --command
+```
+
+Running this will generate a file in `app/commands/age_check.rb` that you can use as a command class.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/tarellel/crossbeam.

--- a/defs.rbi
+++ b/defs.rbi
@@ -1,7 +1,7 @@
 # typed: strong
 # Crossbeam module to include with your service classes
 module Crossbeam
-  VERSION = T.let('0.1.0', T.untyped)
+  VERSION = T.let('0.1.2', T.untyped)
 
   # Used to include/extend modules into the current class
   # 
@@ -287,6 +287,14 @@ class CrossbeamGenerator < Rails::Generators::Base
 
   sig { void }
   def generate_test; end
+
+  # Used to deteremine if the class is a command vs service class
+  sig { returns(String) }
+  def class_directory; end
+
+  # Return the label of the class type
+  sig { returns(String) }
+  def class_type_label; end
 
   # Returns a string to use as the service classes file name
   sig { returns(String) }

--- a/lib/crossbeam/version.rb
+++ b/lib/crossbeam/version.rb
@@ -2,5 +2,5 @@
 
 module Crossbeam
   # @return [String]
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/lib/generators/crossbeam_generator.rb
+++ b/lib/generators/crossbeam_generator.rb
@@ -10,21 +10,36 @@ if defined?(Rails)
 
     argument :class_name, type: :string
     argument :attributes, type: :array, default: [], banner: 'field[:type]'
+    class_option :command, type: :boolean, default: false
     desc 'Generate a Crossbeam service class'
 
     # @return [void]
     def generate_service
-      template 'service_class.rb.tt', "app/services/#{filename}.rb", force: true
+      template 'service_class.rb.tt', "app/#{class_directory}/#{filename}.rb", force: true
     end
 
     # @return [void]
     def generate_test
       return unless Rails.application&.config&.generators&.test_framework == :rspec
 
-      template 'service_spec.rb.tt', "spec/services/#{filename}_spec.rb", force: true
+      template 'service_spec.rb.tt', "spec/#{class_directory}/#{filename}_spec.rb", force: true
     end
 
     private
+
+    # Used to deteremine if the class is a command vs service class
+    #
+    # @return [String]
+    def class_directory
+      @class_directory ||= options[:command] ? 'commands' : 'services'
+    end
+
+    # Return the label of the class type
+    #
+    # @return [String]
+    def class_type_label
+      @class_type_label ||= options[:command] ? 'command' : 'service'
+    end
 
     # Returns a string to use as the service classes file name
     #

--- a/lib/generators/templates/service_spec.rb.tt
+++ b/lib/generators/templates/service_spec.rb.tt
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe <%= class_name.classify %>, type: :helper do
+RSpec.describe <%= class_name.classify %>, type: :<%= class_type_label %> do
   subject { described_class.call }
 
   describe 'an example' do


### PR DESCRIPTION
**Summary:**

* Allow generating of class as a command class rather than always as service class.
* Version bump
* Fix rspec `type:` specified when test is generated